### PR TITLE
Set focus to global search input on icon click

### DIFF
--- a/assets/shared/js/corpus-animation.js
+++ b/assets/shared/js/corpus-animation.js
@@ -43,6 +43,7 @@ var CorpusAnimate = {
         }, 400, function () {
             // Animation complete.
             CorpusAnimate.searchIsOpen = true;
+            $(".global-search-input").focus();
         });
     }
 


### PR DESCRIPTION
When the global search icon is clicked, immediately set focus to the
global search input box so that a second click is not required.