### PR TITLE
Nix corpusspy

### DIFF
--- a/_includes/admin-navigation.html
+++ b/_includes/admin-navigation.html
@@ -2,96 +2,94 @@
    <h4>Search</h4>
    <input data-name="search" data-search-types="section" data-search-name="{{ site.searchname }}{{ context }}" type="text" value="Search" class="side-nav-search-input"/>
 </article>-->
-            
             <!--left sub navigation-->
             <nav id="sidenav">
               <h2>DOCUMENTATION</h2>
-   
               <ul class="nav">
-                <li>
-                  <a href="/admin/overview/" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Overview</a>
+                <li{% if page.url contains "/admin/overview/" %} class="active" {% endif %}>
+                  <a href="/admin/overview/">Overview</a>
                 </li>
-                <li>
-                  <a href="/admin/admin-index.html" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Index</a>
+                <li{% if page.url contains "/admin/admin-index.html" %} class="active" {% endif %}>
+                  <a href="/admin/admin-index.html">Index</a>
                 </li>
-                <li>
-                  <a href="/admin/key-concepts/" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Key Concepts</a>
+                <li{% if page.url contains "/admin/key-concepts/" %} class="active" {% endif %}>
+                  <a href="/admin/key-concepts/">Key Concepts</a>
                 </li>
-                <li>
-                  <a href="/admin/prerequisites/" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Prerequisites</a>
+                <li{% if page.url contains "/admin/prerequisites/" %} class="active" {% endif %}>
+                  <a href="/admin/prerequisites/">Prerequisites</a>
                 </li>
-                <li>
-                  <a href="/admin/getting-started/" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Getting Started</a>
+                <li{% if page.url contains "/admin/getting-started/" %} class="active" {% endif %}>
+                  <a href="/admin/getting-started/">Getting Started</a>
                 </li>
                 <li>
                   <a onclick="$('#admin-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
                   <ul id="admin-typical-usage-scenarios" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/admin/typical-scenarios/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/admin/typical-scenarios/' %} active{% endif %}">
                         <a href="/admin/typical-scenarios/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/admin/typical-scenarios/" and currentpage.url != "/admin/typical-scenarios/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul>
                 </li>
-                <li>
+                <li{% if page.url contains "/admin/best-practices/" %} class="active" {% endif %}>
                   <a onclick="$('#admin-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
                   <ul id="admin-best-practices" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/admin/best-practices/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/admin/best-practices/' %} active{% endif %}">
                         <a href="/admin/best-practices/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/admin/best-practices/" and currentpage.url != "/admin/best-practices/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul>
                 </li>
-                 <li>
+                 <li{% if page.url contains "/admin/references/" %} class="active" {% endif %}>
                   <a onclick="$('#admin-references').toggleClass('hidden');">References
                   <span class="caret"></span></a>
                   <ul id="admin-references" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/admin/references/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/admin/references/' %} active{% endif %}">
                         <a href="/admin/references/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/admin/references/" and currentpage.url != "/admin/references/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul>
                 </li>
-                <li>
+                <li{% if page.url contains "/admin/howto/" %} class="active" {% endif %}>
                   <a onclick="$('#admin-how-to').toggleClass('hidden');">How To
                   <span class="caret"></span></a>
                   <ul id="admin-how-to" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/admin/howto/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/admin/howto/' %} active{% endif %}">
                         <a href="/admin/howto/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/admin/howto/" and currentpage.url != "/admin/howto/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul>
                 </li>
-                <li>
-                  <a href="/admin/tools/" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Tools</a>
+                <li{% if page.url contains "/admin/tools/" %} class="active" {% endif %}>
+                  <a href="/admin/tools/">Tools</a>
                 </li>
-                <li>
-                  <a href="/admin/testing/" {% if page.url contains '/admin/' %} {{ class="active" }} {% endif %}>Testing & Debugging</a>
+                <li{% if page.url contains "/admin/testing/" %} class="active" {% endif %}>
+                  <a href="/admin/testing/">Testing & Debugging</a>
                 </li>
                 <li>
                   <a href="/developer/contribution/">Contribution</a>

--- a/_includes/admin-navigation.html
+++ b/_includes/admin-navigation.html
@@ -24,7 +24,7 @@
                 <li>
                   <a onclick="$('#admin-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
-                  <ul id="admin-typical-usage-scenarios" class="hidden">
+                  <ul id="admin-typical-usage-scenarios"{% unless page.url contains "/admin/typical-scenarios/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/admin/typical-scenarios/' %} active{% endif %}">
                         <a href="/admin/typical-scenarios/index.html">Index</a>
                       </li>
@@ -40,7 +40,7 @@
                 <li{% if page.url contains "/admin/best-practices/" %} class="active" {% endif %}>
                   <a onclick="$('#admin-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
-                  <ul id="admin-best-practices" class="hidden">
+                  <ul id="admin-best-practices"{% unless page.url contains "/admin/best-practices/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/admin/best-practices/' %} active{% endif %}">
                         <a href="/admin/best-practices/index.html">Index</a>
                       </li>
@@ -56,7 +56,7 @@
                  <li{% if page.url contains "/admin/references/" %} class="active" {% endif %}>
                   <a onclick="$('#admin-references').toggleClass('hidden');">References
                   <span class="caret"></span></a>
-                  <ul id="admin-references" class="hidden">
+                  <ul id="admin-references"{% unless page.url contains "/admin/references/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/admin/references/' %} active{% endif %}">
                         <a href="/admin/references/index.html">Index</a>
                       </li>
@@ -72,7 +72,7 @@
                 <li{% if page.url contains "/admin/howto/" %} class="active" {% endif %}>
                   <a onclick="$('#admin-how-to').toggleClass('hidden');">How To
                   <span class="caret"></span></a>
-                  <ul id="admin-how-to" class="hidden">
+                  <ul id="admin-how-to"{% unless page.url contains "/admin/howto/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/admin/howto/' %} active{% endif %}">
                         <a href="/admin/howto/index.html">Index</a>
                       </li>

--- a/_includes/dev-navigation.html
+++ b/_includes/dev-navigation.html
@@ -1,95 +1,94 @@
             <!--left sub navigation-->
             <nav id="sidenav">
               <h2>DOCUMENTATION</h2>
-   
               <ul class="nav">
-                <li>
-                  <a href="/developer/overview/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Overview</a>
+                <li{% if page.url contains "/developer/overview/" %} class="active" {% endif %}>
+                  <a href="/developer/overview/">Overview</a>
                 </li>
-                <li>
-                  <a href="/developer/developer-index.html" class="active" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Index</a>
+                <li{% if page.url contains "/developer/developer-index.html" %} class="active" {% endif %}>
+                  <a href="/developer/developer-index.html">Index</a>
                 </li>
-                <li>
-                  <a href="/developer/key-concepts/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Key Concepts</a>
+                <li{% if page.url contains "/developer/key-concepts/" %} class="active" {% endif %}>
+                  <a href="/developer/key-concepts/">Key Concepts</a>
                 </li>
-                <li>
-                  <a href="/developer/prerequisites/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Prerequisites</a>
+                <li{% if page.url contains "/developer/prerequisites/" %} class="active" {% endif %}>
+                  <a href="/developer/prerequisites/">Prerequisites</a>
                 </li>
-                <li>
-                  <a href="/developer/getting-started/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Getting Started</a>
+                <li{% if page.url contains "/developer/getting-started/" %} class="active" {% endif %}>
+                  <a href="/developer/getting-started/">Getting Started</a>
                 </li>
-                <li>
-                  <a onclick="$('#dev-typical-usage-scenarios').toggleClass('hidden');">Typical Usage Scenarios
+                <li{% if page.url contains "/developer/typical-scenarios/" %} class="active" {% endif %}>
+                  <a onclick="$('#dev-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
                   <ul id="dev-typical-usage-scenarios" class="hidden">
-                    <li class="sub-menu-item{% if page.url == '/developer/typical-scenarios/' %} {{ "active" }} {% endif %}">
+                    <li class="sub-menu-item{% if page.url == '/developer/typical-scenarios/' %} active{% endif %}">
                         <a href="/developer/typical-scenarios/index.html">Index</a>
                       </li>  
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/developer/typical-scenarios/" and currentpage.url != "/developer/typical-scenarios/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ "active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul> 
                 </li>
-                <li>
+                <li{% if page.url contains "/developer/best-practices/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
                   <ul id="dev-best-practices" class="hidden">
-                    <li class="sub-menu-item{% if page.url == '/developer/best-practices/' %} {{ "active" }} {% endif %}">
+                    <li class="sub-menu-item{% if page.url == '/developer/best-practices/' %} active{% endif %}">
                         <a href="/developer/best-practices/index.html">Index</a>
                       </li>  
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/developer/best-practices/" and currentpage.url != "/developer/best-practices/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ "active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul> 
                 </li>
-                <li>
+                <li{% if page.url contains "/developer/references/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-references').toggleClass('hidden');">References
                   <span class="caret"></span></a>
                   <ul id="dev-references" class="hidden">
-                     <li class="sub-menu-item{% if page.url == '/developer/references/' %} {{ "active" }} {% endif %}">
+                     <li class="sub-menu-item{% if page.url == '/developer/references/' %} active{% endif %}">
                         <a href="/developer/references/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/developer/references/" and currentpage.url != "/developer/references/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ "active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul> 
                 </li>
-                <li>
+                <li{% if page.url contains "/developer/howto/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-how-to').toggleClass('hidden');">How To
                   <span class="caret"></span></a>
                   <ul id="dev-how-to" class="hidden">
-                    <li class="sub-menu-item{% if page.url == '/developer/howto/' %} {{ "active" }} {% endif %}">
+                    <li class="sub-menu-item{% if page.url == '/developer/howto/' %} active{% endif %}">
                         <a href="/developer/howto/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/developer/howto/" and currentpage.url != "/developer/howto/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ "active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul> 
                 </li>
-                <li>
-                  <a href="/developer/tools/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Tools</a>
+                <li{% if page.url contains "/developer/tools/" %} class="active" {% endif %}>
+                  <a href="/developer/tools/">Tools</a>
                 </li>
-                <li>
-                  <a href="/developer/testing/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Testing & Debugging</a>
+                <li{% if page.url contains "/developer/testing/" %} class="active" {% endif %}>
+                  <a href="/developer/testing/">Testing & Debugging</a>
                 </li>
-                <li>
-                  <a href="/developer/contribution/" {% if page.url contains '/developer/' %} {{ class="active" }} {% endif %}>Contribution</a>
+                <li{% if page.url contains "/developer/contribution/" %} class="active" {% endif %}>
+                  <a href="/developer/contribution/">Contribution</a>
                 </li>
               </ul>
             </nav>

--- a/_includes/dev-navigation.html
+++ b/_includes/dev-navigation.html
@@ -20,7 +20,7 @@
                 <li{% if page.url contains "/developer/typical-scenarios/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
-                  <ul id="dev-typical-usage-scenarios" class="hidden">
+                  <ul id="dev-typical-usage-scenarios"{% unless page.url contains "/developers/typical-scenarios/" %} class="hidden"{% endunless %}>
                     <li class="sub-menu-item{% if page.url == '/developer/typical-scenarios/' %} active{% endif %}">
                         <a href="/developer/typical-scenarios/index.html">Index</a>
                       </li>  
@@ -36,7 +36,7 @@
                 <li{% if page.url contains "/developer/best-practices/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
-                  <ul id="dev-best-practices" class="hidden">
+                  <ul id="dev-best-practices"{% unless page.url contains "/developer/best-practices/" %} class="hidden"{% endunless %}>
                     <li class="sub-menu-item{% if page.url == '/developer/best-practices/' %} active{% endif %}">
                         <a href="/developer/best-practices/index.html">Index</a>
                       </li>  
@@ -52,7 +52,7 @@
                 <li{% if page.url contains "/developer/references/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-references').toggleClass('hidden');">References
                   <span class="caret"></span></a>
-                  <ul id="dev-references" class="hidden">
+                  <ul id="dev-references"{% unless page.url contains "/developer/references/" %} class="hidden"{% endunless %}>
                      <li class="sub-menu-item{% if page.url == '/developer/references/' %} active{% endif %}">
                         <a href="/developer/references/index.html">Index</a>
                       </li>
@@ -68,7 +68,7 @@
                 <li{% if page.url contains "/developer/howto/" %} class="active" {% endif %}>
                   <a onclick="$('#dev-how-to').toggleClass('hidden');">How To
                   <span class="caret"></span></a>
-                  <ul id="dev-how-to" class="hidden">
+                  <ul id="dev-how-to"{% unless page.url contains "/developer/howto/" %} class="hidden"{% endunless %}>
                     <li class="sub-menu-item{% if page.url == '/developer/howto/' %} active{% endif %}">
                         <a href="/developer/howto/index.html">Index</a>
                       </li>

--- a/_includes/user-navigation.html
+++ b/_includes/user-navigation.html
@@ -1,33 +1,32 @@
             <!--left sub navigation-->
             <nav id="sidenav">
               <h2>DOCUMENTATION</h2>
-   
               <ul class="nav">
-                <li>
-                  <a href="/user/overview/" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Overview</a>
+                <li{% if page.url contains "/user/overview/" %} class="active" {% endif %}>
+                  <a href="/user/overview/">Overview</a>
                 </li>
-                <li>
-                  <a href="/user/user-index.html" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Index</a>
+                <li{% if page.url contains "/user/user-index.html" %} class="active" {% endif %}>
+                  <a href="/user/user-index.html">Index</a>
                 </li>
-                <li>
-                  <a href="/user/key-concepts/" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Key Concepts</a>
+                <li{% if page.url contains "/user/key-concepts/" %} class="active" {% endif %}>
+                  <a href="/user/key-concepts/">Key Concepts</a>
                 </li>
-                <li>
-                  <a href="/user/prerequisites/" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Prerequisites</a>
+                <li{% if page.url contains "/user/prerequisites/" %} class="active" {% endif %}>
+                  <a href="/user/prerequisites/">Prerequisites</a>
                 </li>
-                <li>
-                  <a href="/user/getting-started/" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Getting Started</a>
+                <li{% if page.url contains "/user/getting-started/" %} class="active" {% endif %}>
+                  <a href="/user/getting-started/">Getting Started</a>
                 </li>
                 <li>
                   <a onclick="$('#user-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
                   <ul id="user-typical-usage-scenarios" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/user/typical-scenarios/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/user/typical-scenarios/index.html' %} active{% endif %}">
                         <a href="/user/typical-scenarios/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/user/typical-scenarios/" and currentpage.url != "/user/typical-scenarios/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
@@ -38,12 +37,12 @@
                   <a onclick="$('#user-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
                   <ul id="user-best-practices" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/user/best-practices/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/user/best-practices/index.html' %} active{% endif %}">
                         <a href="/user/best-practices/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/user/best-practices/" and currentpage.url != "/user/best-practices/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
@@ -54,12 +53,12 @@
                   <a onclick="$('#user-references').toggleClass('hidden');">References
                   <span class="caret"></span></a>
                   <ul id="user-references" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/user/references/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/user/references/' %} active{% endif %}">
                         <a href="/user/references/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/user/references/" and currentpage.url != "/user/references/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
@@ -70,23 +69,23 @@
                   <a onclick="$('#user-how-to').toggleClass('hidden');">How To
                   <span class="caret"></span></a>
                   <ul id="user-how-to" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/user/howto/' %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/user/howto/' %} active{% endif %}">
                         <a href="/user/howto/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
                       {% if currentpage.url contains "/user/howto/" and currentpage.url != "/user/howto/" %}
-                      <li class="sub-menu-item{% if page.url == currentpage.url %} {{ " active" }} {% endif %}">
+                      <li class="sub-menu-item{% if page.url == currentpage.url %} active{% endif %}">
                         <a href="{{ currentpage.url }}">{{ currentpage.title }}</a>
                        </li>
                       {% endif %}
                     {% endfor %}
                   </ul>
                 </li>
-                <li>
-                  <a href="/user/tools/" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Tools</a>
+                <li{% if page.url contains "/user/tools/" %} class="active" {% endif %}>
+                  <a href="/user/tools/">Tools</a>
                 </li>
-                <li>
-                  <a href="/user/testing/" {% if page.url contains '/user/' %} {{ class="active" }} {% endif %}>Testing & Debugging</a>
+                <li{% if page.url contains "/user/testing/" %} class="active" {% endif %}>
+                  <a href="/user/testing/">Testing & Debugging</a>
                 </li>
                 <li>
                   <a href="/developer/contribution/">Contribution</a>

--- a/_includes/user-navigation.html
+++ b/_includes/user-navigation.html
@@ -20,7 +20,7 @@
                 <li>
                   <a onclick="$('#user-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
-                  <ul id="user-typical-usage-scenarios" class="hidden">
+                  <ul id="user-typical-usage-scenarios"{% unless page.url contains "/user/typical-scenarios/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/user/typical-scenarios/' %} active{% endif %}">
                         <a href="/user/typical-scenarios/index.html">Index</a>
                       </li>
@@ -36,7 +36,7 @@
                 <li>
                   <a onclick="$('#user-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
-                  <ul id="user-best-practices" class="hidden">
+                  <ul id="user-best-practices"{% unless page.url contains "/user/best-practices/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/user/best-practices/' %} active{% endif %}">
                         <a href="/user/best-practices/index.html">Index</a>
                       </li>
@@ -52,7 +52,7 @@
                 <li>
                   <a onclick="$('#user-references').toggleClass('hidden');">References
                   <span class="caret"></span></a>
-                  <ul id="user-references" class="hidden">
+                  <ul id="user-references"{% unless page.url contains "/user/references/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/user/references/' %} active{% endif %}">
                         <a href="/user/references/index.html">Index</a>
                       </li>
@@ -68,7 +68,7 @@
                 <li>
                   <a onclick="$('#user-how-to').toggleClass('hidden');">How To
                   <span class="caret"></span></a>
-                  <ul id="user-how-to" class="hidden">
+                  <ul id="user-how-to"{% unless page.url contains "/user/howto/" %} class="hidden"{% endunless %}>
                       <li class="sub-menu-item{% if page.url == '/user/howto/' %} active{% endif %}">
                         <a href="/user/howto/index.html">Index</a>
                       </li>

--- a/_includes/user-navigation.html
+++ b/_includes/user-navigation.html
@@ -21,7 +21,7 @@
                   <a onclick="$('#user-typical-usage-scenarios').toggleClass('hidden');">Typical Scenarios
                   <span class="caret"></span></a>
                   <ul id="user-typical-usage-scenarios" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/user/typical-scenarios/index.html' %} active{% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/user/typical-scenarios/' %} active{% endif %}">
                         <a href="/user/typical-scenarios/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}
@@ -37,7 +37,7 @@
                   <a onclick="$('#user-best-practices').toggleClass('hidden');">Best Practices
                   <span class="caret"></span></a>
                   <ul id="user-best-practices" class="hidden">
-                      <li class="sub-menu-item{% if page.url == '/user/best-practices/index.html' %} active{% endif %}">
+                      <li class="sub-menu-item{% if page.url == '/user/best-practices/' %} active{% endif %}">
                         <a href="/user/best-practices/index.html">Index</a>
                       </li>
                     {% for currentpage in site.pages %}

--- a/_layouts/admin-doc.html
+++ b/_layouts/admin-doc.html
@@ -49,7 +49,7 @@
     <script src="{{site.context}}/assets/docs/shared/js/corpus-feedback.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/corpus-sidebar.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/corpus-general.js"></script>
-    <script src="{{site.context}}/assets/docs/shared/js/corpus-spy.js"></script>
+<!--     <script src="{{site.context}}/assets/docs/shared/js/corpus-spy.js"></script> -->
     <script src="{{site.context}}/assets/docs/shared/js/corpus-animation.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/simple-modal.js"></script>
     <script>
@@ -112,9 +112,6 @@
 <script>
     $(document).ready(function() {
         corpus.init();
-        CorpusSpy.init();
-
-
     });
 </script>
     

--- a/_layouts/dev-doc.html
+++ b/_layouts/dev-doc.html
@@ -49,7 +49,7 @@
     <script src="{{site.context}}/assets/docs/shared/js/corpus-feedback.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/corpus-sidebar.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/corpus-general.js"></script>
-    <script src="{{site.context}}/assets/docs/shared/js/corpus-spy.js"></script>
+<!--     <script src="{{site.context}}/assets/docs/shared/js/corpus-spy.js"></script> -->
     <script src="{{site.context}}/assets/docs/shared/js/corpus-animation.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/simple-modal.js"></script>
     <script>
@@ -112,9 +112,6 @@
 <script>
     $(document).ready(function() {
         corpus.init();
-        CorpusSpy.init();
-
-
     });
 </script>
     

--- a/_layouts/user-doc.html
+++ b/_layouts/user-doc.html
@@ -49,7 +49,7 @@
     <script src="{{site.context}}/assets/docs/shared/js/corpus-feedback.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/corpus-sidebar.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/corpus-general.js"></script>
-    <script src="{{site.context}}/assets/docs/shared/js/corpus-spy.js"></script>
+<!--     <script src="{{site.context}}/assets/docs/shared/js/corpus-spy.js"></script> -->
     <script src="{{site.context}}/assets/docs/shared/js/corpus-animation.js"></script>
     <script src="{{site.context}}/assets/docs/shared/js/simple-modal.js"></script>
     <script>
@@ -115,7 +115,6 @@
     <script>
        $(document).ready(function() {
           corpus.init();
-          CorpusSpy.init();
        });
     </script>
     


### PR DESCRIPTION
Completely replaced the corpus-spy JS that used to try to get the nav highlighting right via JS during page runtime with a liquid-based approach that runs at build time. Now works for all pages and removes the JS overhead at runtime and the load of js at page load. Probably can get rid of more corpus stuff but this is a good fix for existing issues. 

Addresses https://github.com/oneops/oneops.github.io/issues/33