### PR TITLE
Updating protocol verb for "Terminated HTTPS Load Balancer" from "terminated_https" to "https"

### DIFF
--- a/user/design/lb-component.md
+++ b/user/design/lb-component.md
@@ -136,7 +136,7 @@ balancer. Connectivity from the load balancer to the backend servers is
 unencrypted:
 
 ```
-terminated_https 443 http 8080
+https 443 http 8080
 ```
 
 This configuration takes incoming HTTPS requests on port 443 and forwards them


### PR DESCRIPTION
This will help to avoid any confusion for users who are using TLS
terminated listeners with netscaler and will also allow seamless
migration from LB to SLB and vice-versa