### PR TITLE
Update secrets-client-component.md

### DIFF
--- a/user/design/secrets-client-component.md
+++ b/user/design/secrets-client-component.md
@@ -66,7 +66,7 @@ mkdir ~/bin
 cd ~/bin
 curl -o secrets http://repo1.maven.org/maven2/com/oneops/secrets-cli/1.0.3/secrets-cli-1.0.3-executable.jar
 chmod a+x secrets
-export PATH=~/bini:$PATH
+export PATH=~/bin:$PATH
 ```
 
 Now you can run the application using the command `secrets info` as a first


### PR DESCRIPTION
There might be a possible typo in the section about downloading the secrets cli

```
export PATH=~/bini:$PATH
```
didn't work on my machine.

```
export PATH=~/bin:$PATH
```
Did work.


Before:
```
mkdir ~/bin
cd ~/bin
curl -o secrets http://repo1.maven.org/maven2/com/oneops/secrets-cli/1.0.3/secrets-cli-1.0.3-executable.jar
chmod a+x secrets
export PATH=~/bini:$PATH
```
After:
```
mkdir ~/bin
cd ~/bin
curl -o secrets http://repo1.maven.org/maven2/com/oneops/secrets-cli/1.0.3/secrets-cli-1.0.3-executable.jar
chmod a+x secrets
export PATH=~/bin:$PATH
```